### PR TITLE
Allow scripts for esbuild, sharp, and workerd dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,10 @@
     "@types/react": "^19.2.17",
     "typescript": "^6.0.3",
     "wrangler": "^4.110.0"
+  },
+  "allowScripts": {
+    "esbuild@0.28.1": true,
+    "sharp@0.34.5": true,
+    "workerd@1.20260708.1": true
   }
 }


### PR DESCRIPTION
## Summary
This change adds an `allowScripts` configuration to package.json to explicitly permit script execution for three key build and runtime dependencies.

## Key Changes
- Added `allowScripts` configuration object to package.json
- Enabled script execution for:
  - `esbuild@0.28.1` - JavaScript bundler used for build optimization
  - `sharp@0.34.5` - Image processing library that may require native compilation
  - `workerd@1.20260708.1` - Cloudflare Workers runtime dependency

## Details
This configuration allows these packages to run their installation scripts, which may be necessary for proper compilation of native modules or setup of platform-specific binaries. This is particularly important for `sharp` which often requires native dependencies, and `workerd` which is a native runtime component.

https://claude.ai/code/session_0171debu3RUZjZyRSfMKkAZV