### PR TITLE
Add repository guidelines, allow fsevents scripts, and fix build output dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /node_modules/
 /.wrangler/
-/.dist
+/dist

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,13 +6,15 @@
 - `functions/utils.ts` contains shared runtime helpers, currently the Google Fonts fetcher.
 - `images/` stores static design assets such as `ogp-background.png`.
 - `wrangler.toml` defines the Pages project, compatibility date, and local server settings.
+- `tsconfig.json` holds the TypeScript compiler configuration.
+- `mise.toml` pins Node.js 24 for mise users; `package.json` `engines` requires Node 24 or newer.
 - `.github/workflows/ci.yml` runs the production build for pull requests.
 
 Keep request handling and image composition in `index.tsx`; move reusable network or transformation logic into focused modules under `functions/`.
 
 ## Build, Test, and Development Commands
 
-Use Node.js 24 or newer:
+Use Node.js 24 or newer (`mise.toml` provides this automatically for mise users):
 
 ```sh
 npm ci
@@ -21,6 +23,8 @@ npm run build
 ```
 
 `npm run dev` starts Wrangler Pages at `http://localhost:8080`. Test an image with `/?title=Hello` or add an encoded `avatar` URL. `npm run build` compiles the Pages Functions bundle into `.dist` and is the same validation CI performs. `npm run deploy` builds and deploys through Wrangler; run it only with the intended Cloudflare account selected.
+
+Dependency install scripts are gated by the `allowScripts` field in `package.json`, which approves specific packages at exact versions (currently `esbuild`, `sharp`, `workerd`, and `fsevents`). When bumping any of these packages, update the pinned version in `allowScripts` in the same change.
 
 ## Coding Style & Naming Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,14 +7,14 @@
 - `images/` stores static design assets such as `ogp-background.png`.
 - `wrangler.toml` defines the Pages project, compatibility date, and local server settings.
 - `tsconfig.json` holds the TypeScript compiler configuration.
-- `mise.toml` pins Node.js 24 for mise users; `package.json` `engines` requires Node 24 or newer.
+- `package.json` `engines` requires Node 24 or newer.
 - `.github/workflows/ci.yml` runs the production build for pull requests.
 
 Keep request handling and image composition in `index.tsx`; move reusable network or transformation logic into focused modules under `functions/`.
 
 ## Build, Test, and Development Commands
 
-Use Node.js 24 or newer (`mise.toml` provides this automatically for mise users):
+Use Node.js 24 or newer:
 
 ```sh
 npm ci

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ npm run dev
 npm run build
 ```
 
-`npm run dev` starts Wrangler Pages at `http://localhost:8080`. Test an image with `/?title=Hello` or add an encoded `avatar` URL. `npm run build` compiles the Pages Functions bundle into `.dist` and is the same validation CI performs. `npm run deploy` builds and deploys through Wrangler; run it only with the intended Cloudflare account selected.
+`npm run dev` starts Wrangler Pages at `http://localhost:8080`. Test an image with `/?title=Hello` or add an encoded `avatar` URL. `npm run build` compiles the Pages Functions bundle into `dist` and is the same validation CI performs. `npm run deploy` builds and deploys through Wrangler; run it only with the intended Cloudflare account selected.
 
 Dependency install scripts are gated by the `allowScripts` field in `package.json`, which approves specific packages at exact versions (currently `esbuild`, `sharp`, `workerd`, and `fsevents`). When bumping any of these packages, update the pinned version in `allowScripts` in the same change.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+- `functions/index.tsx` is the Cloudflare Pages Function entry point. It reads `title` and `avatar` query parameters and returns a 1200×630 Open Graph image.
+- `functions/utils.ts` contains shared runtime helpers, currently the Google Fonts fetcher.
+- `images/` stores static design assets such as `ogp-background.png`.
+- `wrangler.toml` defines the Pages project, compatibility date, and local server settings.
+- `.github/workflows/ci.yml` runs the production build for pull requests.
+
+Keep request handling and image composition in `index.tsx`; move reusable network or transformation logic into focused modules under `functions/`.
+
+## Build, Test, and Development Commands
+
+Use Node.js 24 or newer:
+
+```sh
+npm ci
+npm run dev
+npm run build
+```
+
+`npm run dev` starts Wrangler Pages at `http://localhost:8080`. Test an image with `/?title=Hello` or add an encoded `avatar` URL. `npm run build` compiles the Pages Functions bundle into `.dist` and is the same validation CI performs. `npm run deploy` builds and deploys through Wrangler; run it only with the intended Cloudflare account selected.
+
+## Coding Style & Naming Conventions
+
+Write TypeScript/TSX using two-space indentation, double quotes, semicolons, and trailing commas in multiline objects. Use `camelCase` for variables and functions, `PascalCase` for types or components, and descriptive filenames such as `font-utils.ts`. Prefer explicit types at Cloudflare entry points and shared function boundaries. No formatter or linter is configured, so preserve the surrounding style and verify changes with `npm run build`.
+
+## Testing Guidelines
+
+There is currently no automated test framework or coverage threshold. Every change must pass `npm run build`. For behavior changes, run `npm run dev` and manually check the default response, Japanese or other Unicode titles, missing parameters, and avatar/no-avatar layouts. If adding tests, colocate them as `functions/*.test.ts` or `*.test.tsx` and add the corresponding npm script.
+
+## Commit & Pull Request Guidelines
+
+Recent history favors short imperative subjects and dependency-style Conventional Commit scopes, for example `build(deps-dev): bump typescript ...`. Keep commits focused and include an issue or PR number when relevant. Pull requests should explain the user-visible effect, list local verification, and link related issues. Include a generated-image screenshot when layout, typography, colors, or assets change. Ensure the pull-request build check passes before requesting review.
+
+## Security & Configuration
+
+Do not commit Cloudflare credentials or local environment files. Treat query parameters and fetched remote resources as untrusted input; validate new URLs and avoid exposing secrets in responses or logs.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "allowScripts": {
     "esbuild@0.28.1": true,
     "sharp@0.34.5": true,
-    "workerd@1.20260708.1": true
+    "workerd@1.20260708.1": true,
+    "fsevents@2.3.3": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "login": "wrangler login",
     "setup": "wrangler pages project create og-image-generator --production-branch main",
     "dev": "wrangler pages dev",
-    "build": "wrangler pages functions build --outdir=.dist",
+    "build": "wrangler pages functions build --outdir=dist",
     "deploy": "npm run build && wrangler pages deploy",
     "destroy": "wrangler pages project delete og-image-generator"
   },


### PR DESCRIPTION
## Summary
- Allow `fsevents@2.3.3` in `package.json` script execution permissions
- Add `AGENTS.md` with repository-specific guidance for structure, build, style, testing, and PR expectations
- Fix build output directory mismatch: `npm run build` wrote to `.dist` while `wrangler.toml`'s `pages_build_output_dir` pointed at `./dist`, so `npm run deploy` would have deployed stale/empty output. Standardized on `dist` across `package.json`, `.gitignore`, and `AGENTS.md`.

## Testing
- Ran `npm run build` and confirmed output is written to `dist/` and correctly ignored by git