### PR TITLE
chore(deps): Group Cloudflare Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      cloudflare:
+        patterns:
+          - "@cloudflare/workers-types"
+          - "wrangler"
+        update-types:
+          - minor
+          - patch
     reviewers:
       - toshimaru
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Summary

- group `@cloudflare/workers-types` and `wrangler` Dependabot updates
- limit the group to minor and patch releases
- keep major upgrades, including TypeScript, in separate pull requests

## Why

These Cloudflare tooling updates are reviewed and validated together, so grouping them reduces dependency-update PR noise while preserving separate review for higher-risk major upgrades.

## Validation

- parsed `.github/dependabot.yml` with Ruby YAML
- `git diff --check`
